### PR TITLE
Add CLI login system and unit tests

### DIFF
--- a/DocePimenta/pom.xml
+++ b/DocePimenta/pom.xml
@@ -10,4 +10,24 @@
         <maven.compiler.release>17</maven.compiler.release>
         <exec.mainClass>com.mycompany.docepimenta.DocePimenta</exec.mainClass>
     </properties>
+    <dependencies>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.9.2</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.0.0-M7</version>
+                <configuration>
+                    <useModulePath>false</useModulePath>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/DocePimenta/src/main/java/com/mycompany/docepimenta/cli/DocePimentaCLI.java
+++ b/DocePimenta/src/main/java/com/mycompany/docepimenta/cli/DocePimentaCLI.java
@@ -1,0 +1,23 @@
+package com.mycompany.docepimenta.cli;
+
+import java.util.Scanner;
+
+public class DocePimentaCLI {
+    public static void main(String[] args) {
+        UserService service = new UserService();
+        Scanner scanner = new Scanner(System.in);
+        while (true) {
+            System.out.println("1 - Cadastrar usuário");
+            System.out.println("2 - Login");
+            System.out.println("0 - Sair");
+            System.out.print("Opção: ");
+            String opcao = scanner.nextLine();
+            switch (opcao) {
+                case "1" -> new RegisterCLI().run(service, System.in, System.out);
+                case "2" -> new LoginCLI().run(service, System.in, System.out);
+                case "0" -> { System.out.println("Saindo..."); return; }
+                default -> System.out.println("Opção inválida");
+            }
+        }
+    }
+}

--- a/DocePimenta/src/main/java/com/mycompany/docepimenta/cli/LoginCLI.java
+++ b/DocePimenta/src/main/java/com/mycompany/docepimenta/cli/LoginCLI.java
@@ -1,0 +1,21 @@
+package com.mycompany.docepimenta.cli;
+
+import java.io.InputStream;
+import java.io.PrintStream;
+import java.util.Scanner;
+
+public class LoginCLI {
+    public void run(UserService service, InputStream in, PrintStream out) {
+        Scanner scanner = new Scanner(in);
+        out.print("Usuário: ");
+        String username = scanner.nextLine();
+        out.print("Senha: ");
+        String password = scanner.nextLine();
+        User user = service.login(username, password);
+        if (user != null) {
+            out.println("Bem-vindo " + user.getRole() + " " + user.getUsername() + "!");
+        } else {
+            out.println("Usuário ou senha inválidos.");
+        }
+    }
+}

--- a/DocePimenta/src/main/java/com/mycompany/docepimenta/cli/RegisterCLI.java
+++ b/DocePimenta/src/main/java/com/mycompany/docepimenta/cli/RegisterCLI.java
@@ -1,0 +1,23 @@
+package com.mycompany.docepimenta.cli;
+
+import java.io.InputStream;
+import java.io.PrintStream;
+import java.util.Scanner;
+
+public class RegisterCLI {
+    public void run(UserService service, InputStream in, PrintStream out) {
+        Scanner scanner = new Scanner(in);
+        out.print("Nome de usuário: ");
+        String username = scanner.nextLine();
+        out.print("Senha: ");
+        String password = scanner.nextLine();
+        out.print("Tipo (ADMIN/FUNC1): ");
+        String role = scanner.nextLine();
+        boolean success = service.registerUser(username, password, role);
+        if (success) {
+            out.println("Usuário cadastrado com sucesso!");
+        } else {
+            out.println("Usuário já existe!");
+        }
+    }
+}

--- a/DocePimenta/src/main/java/com/mycompany/docepimenta/cli/User.java
+++ b/DocePimenta/src/main/java/com/mycompany/docepimenta/cli/User.java
@@ -1,0 +1,25 @@
+package com.mycompany.docepimenta.cli;
+
+public class User {
+    private final String username;
+    private final String password;
+    private final String role;
+
+    public User(String username, String password, String role) {
+        this.username = username;
+        this.password = password;
+        this.role = role;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public String getRole() {
+        return role;
+    }
+}

--- a/DocePimenta/src/main/java/com/mycompany/docepimenta/cli/UserService.java
+++ b/DocePimenta/src/main/java/com/mycompany/docepimenta/cli/UserService.java
@@ -1,0 +1,30 @@
+package com.mycompany.docepimenta.cli;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class UserService {
+    private final Map<String, User> users = new HashMap<>();
+
+    public UserService() {
+        // create default users
+        registerUser("admin", "admin", "ADMIN");
+        registerUser("func1", "func1", "FUNC1");
+    }
+
+    public boolean registerUser(String username, String password, String role) {
+        if (users.containsKey(username)) {
+            return false;
+        }
+        users.put(username, new User(username, password, role));
+        return true;
+    }
+
+    public User login(String username, String password) {
+        User user = users.get(username);
+        if (user != null && user.getPassword().equals(password)) {
+            return user;
+        }
+        return null;
+    }
+}

--- a/DocePimenta/src/test/java/com/mycompany/docepimenta/cli/LoginCLITest.java
+++ b/DocePimenta/src/test/java/com/mycompany/docepimenta/cli/LoginCLITest.java
@@ -1,0 +1,35 @@
+package com.mycompany.docepimenta.cli;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class LoginCLITest {
+    private UserService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new UserService();
+    }
+
+    @Test
+    void loginSuccess() {
+        String input = "admin\nadmin\n";
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        new LoginCLI().run(service, new ByteArrayInputStream(input.getBytes(StandardCharsets.UTF_8)), new java.io.PrintStream(out));
+        assertTrue(out.toString().contains("Bem-vindo ADMIN admin"));
+    }
+
+    @Test
+    void loginFail() {
+        String input = "admin\nerrado\n";
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        new LoginCLI().run(service, new ByteArrayInputStream(input.getBytes(StandardCharsets.UTF_8)), new java.io.PrintStream(out));
+        assertTrue(out.toString().contains("Usuário ou senha inválidos"));
+    }
+}

--- a/DocePimenta/src/test/java/com/mycompany/docepimenta/cli/RegisterCLITest.java
+++ b/DocePimenta/src/test/java/com/mycompany/docepimenta/cli/RegisterCLITest.java
@@ -1,0 +1,36 @@
+package com.mycompany.docepimenta.cli;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class RegisterCLITest {
+    private UserService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new UserService();
+    }
+
+    @Test
+    void registerNewUser() {
+        String input = "novo\n123\nFUNC1\n";
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        new RegisterCLI().run(service, new ByteArrayInputStream(input.getBytes(StandardCharsets.UTF_8)), new java.io.PrintStream(out));
+        assertTrue(out.toString().contains("Usuário cadastrado com sucesso"));
+        assertNotNull(service.login("novo", "123"));
+    }
+
+    @Test
+    void registerExistingUser() {
+        String input = "admin\n123\nADMIN\n";
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        new RegisterCLI().run(service, new ByteArrayInputStream(input.getBytes(StandardCharsets.UTF_8)), new java.io.PrintStream(out));
+        assertTrue(out.toString().contains("Usuário já existe"));
+    }
+}

--- a/DocePimenta/src/test/java/com/mycompany/docepimenta/cli/UserServiceTest.java
+++ b/DocePimenta/src/test/java/com/mycompany/docepimenta/cli/UserServiceTest.java
@@ -1,0 +1,29 @@
+package com.mycompany.docepimenta.cli;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class UserServiceTest {
+    private UserService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new UserService();
+    }
+
+    @Test
+    void registerAndLogin() {
+        assertTrue(service.registerUser("novo", "123", "FUNC1"));
+        assertFalse(service.registerUser("novo", "outro", "FUNC1"));
+        User user = service.login("novo", "123");
+        assertNotNull(user);
+        assertEquals("FUNC1", user.getRole());
+    }
+
+    @Test
+    void loginInvalid() {
+        assertNull(service.login("naoexiste", "123"));
+    }
+}


### PR DESCRIPTION
## Summary
- add junit and surefire plugin
- create simple CLI classes for user registration and login
- provide in-memory user service with default `admin` and `func1`
- add unit tests for the CLI screens

## Testing
- `mvn -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_687ada126c64832697cead92af98c99f