### PR TITLE
Add CLI user management with tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+zip_contents/
+**/target/

--- a/DocePimenta/pom.xml
+++ b/DocePimenta/pom.xml
@@ -8,6 +8,26 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.release>17</maven.compiler.release>
-        <exec.mainClass>com.mycompany.docepimenta.DocePimenta</exec.mainClass>
+        <exec.mainClass>cli.TerminalApp</exec.mainClass>
     </properties>
+    <dependencies>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.9.2</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.0.0-M9</version>
+                <configuration>
+                    <useModulePath>false</useModulePath>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/DocePimenta/src/main/java/cli/TerminalApp.java
+++ b/DocePimenta/src/main/java/cli/TerminalApp.java
@@ -1,0 +1,68 @@
+package cli;
+
+import java.io.IOException;
+import java.nio.file.Paths;
+import java.util.Scanner;
+
+public class TerminalApp {
+    public static void main(String[] args) throws Exception {
+        Scanner scanner = new Scanner(System.in);
+        UserService service = new UserService(Paths.get("users.txt"));
+
+        while (true) {
+            System.out.println("\n1. Cadastrar Usuário");
+            System.out.println("2. Login");
+            System.out.println("3. Sair");
+            System.out.print("Escolha: ");
+            String opt = scanner.nextLine();
+
+            switch (opt) {
+                case "1":
+                    cadastrar(scanner, service);
+                    break;
+                case "2":
+                    login(scanner, service);
+                    break;
+                case "3":
+                    System.out.println("Encerrando...");
+                    return;
+                default:
+                    System.out.println("Opção inválida");
+            }
+        }
+    }
+
+    private static void cadastrar(Scanner scanner, UserService service) throws IOException {
+        System.out.print("Usuário: ");
+        String usuario = scanner.nextLine();
+        System.out.print("Senha: ");
+        String senha = scanner.nextLine();
+        System.out.print("Tipo (admin/func1): ");
+        String tipo = scanner.nextLine();
+
+        if (!tipo.equals("admin") && !tipo.equals("func1")) {
+            System.out.println("Tipo inválido");
+            return;
+        }
+
+        if (service.register(usuario, senha, tipo)) {
+            System.out.println("Usuário cadastrado!");
+        } else {
+            System.out.println("Usuário já existe!");
+        }
+    }
+
+    private static void login(Scanner scanner, UserService service) {
+        System.out.print("Usuário: ");
+        String usuario = scanner.nextLine();
+        System.out.print("Senha: ");
+        String senha = scanner.nextLine();
+
+        User user = service.authenticate(usuario, senha);
+        if (user != null) {
+            System.out.println("Login realizado! Tipo: " + user.getRole());
+        } else {
+            System.out.println("Usuário ou senha incorretos");
+        }
+    }
+}

--- a/DocePimenta/src/main/java/cli/User.java
+++ b/DocePimenta/src/main/java/cli/User.java
@@ -1,0 +1,25 @@
+package cli;
+
+public class User {
+    private final String username;
+    private final String password;
+    private final String role;
+
+    public User(String username, String password, String role) {
+        this.username = username;
+        this.password = password;
+        this.role = role;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public String getRole() {
+        return role;
+    }
+}

--- a/DocePimenta/src/main/java/cli/UserService.java
+++ b/DocePimenta/src/main/java/cli/UserService.java
@@ -1,0 +1,53 @@
+package cli;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.HashMap;
+import java.util.Map;
+
+public class UserService {
+    private final Path storageFile;
+    private final Map<String, User> users = new HashMap<>();
+
+    public UserService(Path storageFile) throws IOException {
+        this.storageFile = storageFile;
+        load();
+    }
+
+    private void load() throws IOException {
+        if (!Files.exists(storageFile)) {
+            return;
+        }
+        for (String line : Files.readAllLines(storageFile)) {
+            String[] parts = line.split(",");
+            if (parts.length == 3) {
+                users.put(parts[0], new User(parts[0], parts[1], parts[2]));
+            }
+        }
+    }
+
+    private void save(User user) throws IOException {
+        String line = user.getUsername() + "," + user.getPassword() + "," + user.getRole() + System.lineSeparator();
+        Files.writeString(storageFile, line, StandardOpenOption.CREATE, StandardOpenOption.APPEND);
+    }
+
+    public boolean register(String username, String password, String role) throws IOException {
+        if (users.containsKey(username)) {
+            return false;
+        }
+        User user = new User(username, password, role);
+        users.put(username, user);
+        save(user);
+        return true;
+    }
+
+    public User authenticate(String username, String password) {
+        User user = users.get(username);
+        if (user != null && user.getPassword().equals(password)) {
+            return user;
+        }
+        return null;
+    }
+}

--- a/DocePimenta/src/test/java/cli/UserServiceTest.java
+++ b/DocePimenta/src/test/java/cli/UserServiceTest.java
@@ -1,0 +1,43 @@
+package cli;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class UserServiceTest {
+    private Path tempFile;
+    private UserService service;
+
+    @BeforeEach
+    public void setup() throws IOException {
+        tempFile = Files.createTempFile("users", ".txt");
+        service = new UserService(tempFile);
+    }
+
+    @Test
+    public void testRegisterAndLoginAdmin() throws IOException {
+        assertTrue(service.register("admin", "123", "admin"));
+        User user = service.authenticate("admin", "123");
+        assertNotNull(user);
+        assertEquals("admin", user.getRole());
+    }
+
+    @Test
+    public void testRegisterAndLoginFunc1() throws IOException {
+        assertTrue(service.register("func", "abc", "func1"));
+        User user = service.authenticate("func", "abc");
+        assertNotNull(user);
+        assertEquals("func1", user.getRole());
+    }
+
+    @Test
+    public void testLoginFail() throws IOException {
+        service.register("user", "pass", "func1");
+        User user = service.authenticate("user", "wrong");
+        assertNull(user);
+    }
+}


### PR DESCRIPTION
## Summary
- add basic CLI user system
- allow registering and authenticating users of type `admin` or `func1`
- include JUnit tests for user registration and login
- update pom.xml with dependencies and surefire plugin
- ignore Maven target directories

## Testing
- `mvn -q test -f DocePimenta/pom.xml` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_687ada126c64832697cead92af98c99f